### PR TITLE
Fix canvas feature interface name

### DIFF
--- a/packages/aurum-canvas/src/components/canvas.tsx
+++ b/packages/aurum-canvas/src/components/canvas.tsx
@@ -12,7 +12,7 @@ import {
     dsMap,
     dsUnique
 } from 'aurumjs';
-import { AurumnCanvasFeatures } from './canvas_feature_model.js';
+import { AurumCanvasFeatures } from './canvas_feature_model.js';
 import { SimplifiedKeyboardEvent, SimplifiedMouseEvent, SimplifiedWheelEvent } from './common_props.js';
 import { AurumOffscreenCanvas } from './offscreen_canvas.js';
 
@@ -40,7 +40,7 @@ export interface AurumCanvasProps {
     height?: ReadOnlyDataSource<string | number> | ReadOnlyDataSource<string> | ReadOnlyDataSource<number> | string | number;
     translate?: DataSource<{ x: number; y: number }>;
     scale?: DataSource<{ x: number; y: number }>;
-    features?: AurumnCanvasFeatures;
+    features?: AurumCanvasFeatures;
     /**
      * In case of auto size this will update to the current width of the canvas
      */

--- a/packages/aurum-canvas/src/components/canvas_feature_model.ts
+++ b/packages/aurum-canvas/src/components/canvas_feature_model.ts
@@ -1,4 +1,4 @@
-export interface AurumnCanvasFeatures {
+export interface AurumCanvasFeatures {
     mouseWheelZoom?: {
         zoomIncrements: number;
         maxZoom: number;

--- a/packages/aurum-canvas/src/components/offscreen_canvas.tsx
+++ b/packages/aurum-canvas/src/components/offscreen_canvas.tsx
@@ -10,7 +10,7 @@ import {
     createLifeCycle,
     dsUnique
 } from 'aurumjs';
-import { AurumnCanvasFeatures } from './canvas_feature_model.js';
+import { AurumCanvasFeatures } from './canvas_feature_model.js';
 import { ComponentModel, ComponentType } from './component_model.js';
 import { BezierCurveComponentModel } from './drawables/aurum_bezier_curve.js';
 import { ElipseComponentModel } from './drawables/aurum_elipse.js';
@@ -40,7 +40,7 @@ export interface AurumOffscreenCanvasProps {
     backgroundColor?: DataSource<string> | string;
     translate?: DataSource<{ x: number; y: number }>;
     scale?: DataSource<{ x: number; y: number }>;
-    features?: AurumnCanvasFeatures;
+    features?: AurumCanvasFeatures;
     /**
      * In case of auto size this will update to the current width of the canvas
      */


### PR DESCRIPTION
## Summary
- rename `AurumnCanvasFeatures` to `AurumCanvasFeatures`
- update references in `canvas.tsx` and `offscreen_canvas.tsx`

## Testing
- `npx tsc packages/aurum-canvas/src/components/canvas.tsx packages/aurum-canvas/src/components/offscreen_canvas.tsx --jsx react --jsxFactory Aurum.factory --jsxFragmentFactory Aurum.fragment --allowSyntheticDefaultImports --esModuleInterop --moduleResolution node --module esnext --noEmit` *(fails: Cannot find module 'aurumjs')*

------
https://chatgpt.com/codex/tasks/task_e_68402bc9d4fc832089ce9962e814f303