### PR TITLE
Fix typo in EventEmitter comment

### DIFF
--- a/packages/aurum/src/utilities/event_emitter.ts
+++ b/packages/aurum/src/utilities/event_emitter.ts
@@ -157,7 +157,7 @@ export class EventEmitter<T> {
     }
 
     /**
-     * Removes all currently active subscriptions. If called in the callback of a subscription will be defered until after the fire event finished
+     * Removes all currently active subscriptions. If called in the callback of a subscription will be deferred until after the fire event finished
      */
     public cancelAll(): void {
         if (!this.isFiring) {


### PR DESCRIPTION
## Summary
- fix typo in `EventEmitter` comment in event_emitter.ts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402bda460083208ee2c05fcc877bdf