### PR TITLE
Add failing subscriber test for EventEmitter

### DIFF
--- a/packages/aurum/test/event_emitter.test.ts
+++ b/packages/aurum/test/event_emitter.test.ts
@@ -73,4 +73,18 @@ describe('EventEmitter', () => {
 
         expect(callback).not.toHaveBeenCalled();
     });
+
+    it('should throw from fire while still calling other subscribers', () => {
+        const emitter = new EventEmitter<string>();
+        const goodCallback = vi.fn();
+        const badCallback = vi.fn(() => {
+            throw new Error('bad');
+        });
+
+        emitter.subscribe(badCallback);
+        emitter.subscribe(goodCallback);
+
+        expect(() => emitter.fire('value')).toThrowError('bad');
+        expect(goodCallback).toHaveBeenCalledWith('value');
+    });
 });


### PR DESCRIPTION
## Summary
- cover `fire` with a throwing subscriber and ensure other callbacks run

## Testing
- `npx -y vitest run packages/aurum/test/event_emitter.test.ts` *(fails: Cannot access 'Object' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68402bed82288320af01ee0534c83039